### PR TITLE
Support Quantilized Fully Connected

### DIFF
--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -79,6 +79,8 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
   const int m = dshape[0], n = wshape[0], k = dshape.ProdShape(1, dshape.ndim());
 
   for (int i = 0; i < m * k; i++) {
+    //  cblas_gemm_s8u8s32 required first matrix must be uint8
+    //  shift data from int8(from -128 to 127) to uint8 (from 0 to 255)
     shift_data.data().dptr<uint8_t>()[i] = data.data().dptr<int8_t>()[i] + 128;
   }
 

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -142,7 +142,7 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
                      n,
                      &oc);
   #else
-    LOG(FATAL) << "s8u8s32 is not supported by the BLAS library";
+    LOG(FATAL) << "s8u8s32 is only supported by MKL BLAS library";
   #endif
 }
 

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -111,10 +111,11 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
       output_temp[i] = 0;
     }
   }
-
   #pragma omp parallel for num_threads(omp_threads)
-  for (int i = 0; i < n * k; ++i) {
-    output_temp[i / k] -= shift * weight_temp[i];
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < k; ++j) {
+      output_temp[i] -= shift * weight_temp[i * k + j];
+    }
   }
   #pragma omp parallel for num_threads(omp_threads)
   for (int i = n; i < m * n; ++i) {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -88,7 +88,7 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
   Stream<cpu> *s = ctx.get_stream<cpu>();
   //  cblas_gemm_s8u8s32 required first matrix must be uint8
   //  shift data from int8(from -128 to 127) to uint8 (from 0 to 255)
-  Kernel<QuantizedShiftKernel, cpu>::Launch(s, m * k, data.data().dptr<int8_t>(), 
+  Kernel<QuantizedShiftKernel, cpu>::Launch(s, m * k, data.data().dptr<int8_t>(),
       shift_data.data().dptr<uint8_t>(), 128);
 
   cblas_gemm_s8u8s32(CblasRowMajor,
@@ -109,7 +109,7 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
                      out.data().dptr<int32_t>(),
                      n,
                      &oc);
-  
+
   Kernel<QuantizationRangeForMultiplicationStruct, cpu>::Launch(s, 1,
       out_data[1].data().dptr<float>(), out_data[2].data().dptr<float>(),
       in_data[num_inputs].data().dptr<float>(),   in_data[num_inputs+1].data().dptr<float>(),

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -26,8 +26,8 @@
 namespace mxnet {
 namespace op {
 
-namespace quantilizedfc {
-enum QuantilizedfcOpResource {kTempSpace};
+namespace quantized_fullc {
+enum QuantizedFullyConnectedOpResource {kTempSpace};
 }
 
 struct QuantizedShiftKernel {
@@ -54,7 +54,7 @@ struct QuantizedSumInitKernelWithBias {
       out[i] = bias[i] * float_for_one_bias_quant /
                float_for_one_out_quant;
     } else {
-      LOG(INFO) << "WARNING: QuantizedBiasAddKernel float_for_one_out_quant is 0 !";
+      LOG(INFO) << "WARNING: QuantizedSumInitKernelWithBias float_for_one_out_quant is 0 !";
       out[i] = 0;
     }
   }
@@ -112,7 +112,7 @@ void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
   //  shift data from int8(from -128 to 127) to uint8 (from 0 to 255)
   int shift = 128;
   Tensor<cpu, 1, uint8_t> shiftdata =
-    ctx.requested[quantilizedfc::kTempSpace].get_space_typed<cpu, 1, uint8_t>(
+    ctx.requested[quantized_fullc::kTempSpace].get_space_typed<cpu, 1, uint8_t>(
       Shape1(m * k), s);
   Kernel<QuantizedShiftKernel, cpu>::Launch(s, m * k, data.data().dptr<SrcType>(),
       shiftdata.dptr_, shift);

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_fully_connected.cc
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#if MXNET_USE_MKLDNN == 1
+
+#include "../../nn/mkldnn/mkldnn_base-inl.h"
+#include "../quantization_utils.h"
+#include "../../nn/fully_connected-inl.h"
+
+namespace mxnet {
+namespace op {
+
+// value + bias_value * (range1 / limit_range1) * (limit_range2 / range2)
+struct QuantizedBiasAddKernel {
+  MSHADOW_XINLINE static void Map(int i, size_t k, int32_t *out,
+                                  const int8_t *bias, const float *min_out,
+                                  const float *max_out, const float *min_bias,
+                                  const float *max_bias) {
+    typedef int32_t T1;
+    typedef int8_t  T2;
+    using mshadow::red::limits::MinValue;
+    using mshadow::red::limits::MaxValue;
+    float float_for_one_out_quant  =
+      MaxAbs(*min_out, *max_out) / static_cast<double>(MaxValue<T1>());
+    float float_for_one_bias_quant =
+      MaxAbs(*min_bias, *max_bias) / static_cast<double>(MaxValue<T2>());
+    if (float_for_one_out_quant != 0) {
+      out[i] = (out[i] * float_for_one_out_quant +
+                bias[i%k] * float_for_one_bias_quant) /
+               float_for_one_out_quant;
+    } else {
+      LOG(INFO) << "WARNING: QuantizedBiasAddKernel float_for_one_out_quant is 0 !";
+    }
+  }
+};
+
+template<typename SrcType, typename DstType, typename CmpType>
+void MKLDNNQuantizedFullyConnectedForward(const nnvm::NodeAttrs& attrs,
+                                       const OpContext &ctx,
+                                       const std::vector<NDArray> &in_data,
+                                       const std::vector<OpReqType> &req,
+                                       const std::vector<NDArray> &out_data) {
+  const FullyConnectedParam& param = nnvm::get<FullyConnectedParam>(attrs.parsed);
+  using namespace mshadow;
+  using namespace mxnet_op;
+  size_t num_inputs = param.no_bias ? 2 : 3;
+  CHECK_EQ(in_data.size(),  num_inputs * 3);
+  CHECK_EQ(out_data.size(), 3U);
+  const NDArray& data   =  in_data[0];
+  const NDArray& weight =  in_data[1];
+  const NDArray& out    = out_data[0];
+  TShape dshape = data.shape();
+  TShape wshape = weight.shape();
+  TShape oshape = out.shape();
+
+  CHECK(in_data[0].dtype() == mshadow::kInt8
+    && in_data[1].dtype() == mshadow::kInt8)
+    << "mkldnn_quantized_FullyConnected op only supports int8 as input type";
+
+  const float alpha = 1.0f;
+  const float beta  = 0.0f;
+  const CBLAS_OFFSET offsetc = CblasFixOffset;
+  const MKL_INT8 oa = -128;
+  const MKL_INT8 ob = 0;
+  MKL_INT32 oc = 0;
+  const int m = dshape[0], n = wshape[0], k = dshape.ProdShape(1, dshape.ndim());
+  const int omp_threads = mxnet::engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
+  uint8_t* pDataNewRange = reinterpret_cast<uint8_t*>(malloc(m*k*sizeof(uint8_t)));
+
+  #pragma omp parallel for num_threads(omp_threads)
+  for (int i = 0; i < m * k; i++) {
+    pDataNewRange[i] = data.data().dptr<int8_t>()[i] + 128;
+  }
+
+  cblas_gemm_s8u8s32(CblasRowMajor,
+                     CblasNoTrans,
+                     CblasTrans,
+                     offsetc,
+                     m,
+                     n,
+                     k,
+                     alpha,
+                     pDataNewRange,
+                     k,
+                     oa,
+                     weight.data().dptr<int8_t>(),
+                     k,
+                     ob,
+                     beta,
+                     out.data().dptr<int32_t>(),
+                     n,
+                     &oc);
+
+  free(pDataNewRange);
+  Stream<cpu> *s = ctx.get_stream<cpu>();
+  Kernel<QuantizationRangeForMultiplicationStruct, cpu>::Launch(s, 1,
+     out_data[1].data().dptr<float>(), out_data[2].data().dptr<float>(),
+     in_data[num_inputs].data().dptr<float>(),   in_data[num_inputs+1].data().dptr<float>(),
+     in_data[num_inputs+2].data().dptr<float>(), in_data[num_inputs+3].data().dptr<float>());
+
+  if (!param.no_bias) {
+    const NDArray& bias = in_data[2];
+    Kernel<QuantizedBiasAddKernel, cpu>::Launch(s, out.shape().Size(),
+        n, out.data().dptr<int32_t>(), bias.data().dptr<int8_t>(),
+        out_data[1].data().dptr<float>(), out_data[2].data().dptr<float>(),
+         in_data[7].data().dptr<float>(),  in_data[8].data().dptr<float>());
+  }
+}
+
+NNVM_REGISTER_OP(_contrib_quantized_fully_connected)
+.set_attr<FComputeEx>("FComputeEx<cpu>",
+    MKLDNNQuantizedFullyConnectedForward<int8_t, int32_t, int32_t>);
+
+
+}  // namespace op
+}  // namespace mxnet
+#endif
+

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -132,7 +132,6 @@ and max thresholds representing the threholds for quantizing the float32 output 
 .set_attr<nnvm::FInferType>("FInferType", QuantizedFullyConnectedType)
 .set_attr<FInferStorageType>("FInferStorageType", QuantizedFullyConnectedStorageType)
 .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
-.add_argument("shiftdata", "NDArray-or-Symbol", "Input data.")
 .add_argument("data", "NDArray-or-Symbol", "Input data.")
 .add_argument("weight", "NDArray-or-Symbol", "weight.")
 .add_argument("bias", "NDArray-or-Symbol", "bias.")

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -36,7 +36,7 @@ bool QuantizedFullyConnectedShape(const nnvm::NodeAttrs& attrs,
   using namespace mshadow;
   uint32_t num_inputs = param.no_bias ? 2 : 3;
   CHECK_EQ(in_shape->size(), num_inputs * 3);
-  CHECK_EQ(out_shape->size(), 4U);
+  CHECK_EQ(out_shape->size(), 3U);
 
   CHECK(!shape_is_none(in_shape->at(0)))
     << "QuantizedFullyConnectedOp input data shape must be given";
@@ -55,7 +55,6 @@ bool QuantizedFullyConnectedShape(const nnvm::NodeAttrs& attrs,
   SHAPE_ASSIGN_CHECK(*out_shape, 0, TShape({dshape[0], wshape[0]}));
   SHAPE_ASSIGN_CHECK(*out_shape, 1, TShape({1}));
   SHAPE_ASSIGN_CHECK(*out_shape, 2, TShape({1}));
-  SHAPE_ASSIGN_CHECK(*out_shape, 3, dshape);
   return true;
 }
 
@@ -65,7 +64,7 @@ bool QuantizedFullyConnectedType(const nnvm::NodeAttrs& attrs,
   const FullyConnectedParam& param = nnvm::get<FullyConnectedParam>(attrs.parsed);
   uint32_t num_inputs = param.no_bias ? 2 : 3;
   CHECK_EQ(in_type->size(), num_inputs * 3);
-  CHECK_EQ(out_type->size(), 4U);
+  CHECK_EQ(out_type->size(), 3U);
 
   for (size_t i = 0; i < num_inputs; ++i) {
     TYPE_ASSIGN_CHECK(*in_type, i, mshadow::kInt8);
@@ -77,7 +76,6 @@ bool QuantizedFullyConnectedType(const nnvm::NodeAttrs& attrs,
   TYPE_ASSIGN_CHECK(*out_type, 0, mshadow::kInt32);
   TYPE_ASSIGN_CHECK(*out_type, 1, mshadow::kFloat32);
   TYPE_ASSIGN_CHECK(*out_type, 2, mshadow::kFloat32);
-  TYPE_ASSIGN_CHECK(*out_type, 3, mshadow::kUint8);
   return true;
 }
 
@@ -111,7 +109,7 @@ and max thresholds representing the threholds for quantizing the float32 output 
     const FullyConnectedParam& param = nnvm::get<FullyConnectedParam>(attrs.parsed);
     return param.no_bias? 6 : 9;
   })
-.set_num_outputs(4)
+.set_num_outputs(3)
 .set_attr_parser(ParamParser<FullyConnectedParam>)
 .set_attr<nnvm::FListInputNames>("FListInputNames",
   [](const NodeAttrs& attrs) {
@@ -126,7 +124,7 @@ and max thresholds representing the threholds for quantizing the float32 output 
   })
 .set_attr<nnvm::FListOutputNames>("FListOutputNames",
   [](const NodeAttrs& attrs) {
-    return std::vector<std::string>{"output", "min_output", "max_output", "shift_data"};
+    return std::vector<std::string>{"output", "min_output", "max_output"};
   })
 .set_attr<nnvm::FInferShape>("FInferShape", QuantizedFullyConnectedShape)
 .set_attr<nnvm::FInferType>("FInferType", QuantizedFullyConnectedType)

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -36,7 +36,7 @@ bool QuantizedFullyConnectedShape(const nnvm::NodeAttrs& attrs,
   using namespace mshadow;
   uint32_t num_inputs = param.no_bias ? 2 : 3;
   CHECK_EQ(in_shape->size(), num_inputs * 3);
-  CHECK_EQ(out_shape->size(), 3U);
+  CHECK_EQ(out_shape->size(), 4U);
 
   CHECK(!shape_is_none(in_shape->at(0)))
     << "QuantizedFullyConnectedOp input data shape must be given";
@@ -55,6 +55,7 @@ bool QuantizedFullyConnectedShape(const nnvm::NodeAttrs& attrs,
   SHAPE_ASSIGN_CHECK(*out_shape, 0, TShape({dshape[0], wshape[0]}));
   SHAPE_ASSIGN_CHECK(*out_shape, 1, TShape({1}));
   SHAPE_ASSIGN_CHECK(*out_shape, 2, TShape({1}));
+  SHAPE_ASSIGN_CHECK(*out_shape, 3, dshape);
   return true;
 }
 
@@ -64,7 +65,7 @@ bool QuantizedFullyConnectedType(const nnvm::NodeAttrs& attrs,
   const FullyConnectedParam& param = nnvm::get<FullyConnectedParam>(attrs.parsed);
   uint32_t num_inputs = param.no_bias ? 2 : 3;
   CHECK_EQ(in_type->size(), num_inputs * 3);
-  CHECK_EQ(out_type->size(), 3U);
+  CHECK_EQ(out_type->size(), 4U);
 
   for (size_t i = 0; i < num_inputs; ++i) {
     TYPE_ASSIGN_CHECK(*in_type, i, mshadow::kInt8);
@@ -76,6 +77,7 @@ bool QuantizedFullyConnectedType(const nnvm::NodeAttrs& attrs,
   TYPE_ASSIGN_CHECK(*out_type, 0, mshadow::kInt32);
   TYPE_ASSIGN_CHECK(*out_type, 1, mshadow::kFloat32);
   TYPE_ASSIGN_CHECK(*out_type, 2, mshadow::kFloat32);
+  TYPE_ASSIGN_CHECK(*out_type, 3, mshadow::kUint8);
   return true;
 }
 
@@ -109,7 +111,7 @@ and max thresholds representing the threholds for quantizing the float32 output 
     const FullyConnectedParam& param = nnvm::get<FullyConnectedParam>(attrs.parsed);
     return param.no_bias? 6 : 9;
   })
-.set_num_outputs(3)
+.set_num_outputs(4)
 .set_attr_parser(ParamParser<FullyConnectedParam>)
 .set_attr<nnvm::FListInputNames>("FListInputNames",
   [](const NodeAttrs& attrs) {
@@ -124,12 +126,13 @@ and max thresholds representing the threholds for quantizing the float32 output 
   })
 .set_attr<nnvm::FListOutputNames>("FListOutputNames",
   [](const NodeAttrs& attrs) {
-    return std::vector<std::string>{"output", "min_output", "max_output"};
+    return std::vector<std::string>{"output", "min_output", "max_output", "shift_data"};
   })
 .set_attr<nnvm::FInferShape>("FInferShape", QuantizedFullyConnectedShape)
 .set_attr<nnvm::FInferType>("FInferType", QuantizedFullyConnectedType)
 .set_attr<FInferStorageType>("FInferStorageType", QuantizedFullyConnectedStorageType)
 .set_attr<FNeedRequantize>("FNeedRequantize", [](const NodeAttrs& attrs) { return true; })
+.add_argument("shiftdata", "NDArray-or-Symbol", "Input data.")
 .add_argument("data", "NDArray-or-Symbol", "Input data.")
 .add_argument("weight", "NDArray-or-Symbol", "weight.")
 .add_argument("bias", "NDArray-or-Symbol", "bias.")

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -80,10 +80,10 @@ bool QuantizedFullyConnectedType(const nnvm::NodeAttrs& attrs,
 }
 
 bool QuantizedFullyConnectedStorageType(const nnvm::NodeAttrs& attrs,
-                              const int dev_mask,
-                              DispatchMode* dispatch_mode,
-                              std::vector<int> *in_attrs,
-                              std::vector<int> *out_attrs) {
+                                        const int dev_mask,
+                                        DispatchMode* dispatch_mode,
+                                        std::vector<int> *in_attrs,
+                                        std::vector<int> *out_attrs) {
   *dispatch_mode = DispatchMode::kFCompute;
 #if MXNET_USE_MKLDNN == 1
   if (dev_mask == mshadow::cpu::kDevMask) {

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -269,10 +269,7 @@ def test_quantized_pooling():
 @with_seed()
 def test_quantized_fc():
     def check_quantized_fc(data_shape, num_hidden, no_bias, qdtype, flatten=True):
-        if mx.current_context().device_type != 'gpu':
-            print('skipped testing quantized_fc on cpu since it is not supported yet')
-            return
-        elif qdtype == 'uint8' and is_test_for_gpu():
+        if qdtype == 'uint8' and is_test_for_gpu():
             print('skipped testing quantized_fc for gpu uint8 since it is not supported yet')
             return
 
@@ -283,17 +280,17 @@ def test_quantized_fc():
         fc_fp32_exe = fc_fp32.simple_bind(ctx=mx.current_context(), grad_req='null')
         if qdtype == 'uint8':
             data_low = 0.0
-            data_high = 127.0
+            data_high = 63.0
         else:
-            data_low = -127.0
-            data_high = 127.0
+            data_low = -63.0
+            data_high = 63.0
         fc_fp32_exe.arg_dict[arg_names[0]][:] = mx.nd.random.uniform(low=data_low, high=data_high,
-                                                                     shape=data_shape).astype('int32')
-        fc_fp32_exe.arg_dict[arg_names[1]][:] = mx.nd.random.uniform(low=-127.0, high=127.0,
-                                                                     shape=arg_shapes[1]).astype('int32')
+                                                                     shape=data_shape).astype('int8')
+        fc_fp32_exe.arg_dict[arg_names[1]][:] = mx.nd.random.uniform(low=data_low, high=data_high,
+                                                                     shape=arg_shapes[1]).astype('int8')
         if not no_bias:
-            fc_fp32_exe.arg_dict[arg_names[2]][:] = mx.nd.random.uniform(low=-127.0, high=127.0,
-                                                                         shape=arg_shapes[2]).astype('int32')
+            fc_fp32_exe.arg_dict[arg_names[2]][:] = mx.nd.random.uniform(low=data_low, high=data_high,
+                                                                         shape=arg_shapes[2]).astype('int8')
         output = fc_fp32_exe.forward()[0]
 
         qdata = mx.sym.Variable(name='qdata', shape=data_shape, dtype='int8')
@@ -335,6 +332,10 @@ def test_quantized_fc():
         check_quantized_fc((32, 111, 2, 2), 100, True, qdtype)
         check_quantized_fc((32, 512, 2, 2), 100, False, qdtype)
         check_quantized_fc((32, 111, 2, 2), 100, False, qdtype)
+        check_quantized_fc((256, 2048, 2, 2), 800, False, qdtype)
+        check_quantized_fc((256, 111, 2, 2), 800, False, qdtype)
+        check_quantized_fc((256, 2048, 2, 2), 800, True, qdtype)
+        check_quantized_fc((256, 111, 2, 2), 800, True, qdtype)
 
 @with_seed()
 def test_quantized_flatten():

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -317,7 +317,7 @@ def test_quantized_fc():
             fc_int8_exe.arg_dict[qarg_names[6]][:] = quantized_range
             fc_int8_exe.arg_dict[qarg_names[7]][:] = -quantized_range
             fc_int8_exe.arg_dict[qarg_names[8]][:] = quantized_range
-        qoutput, min_range, max_range = fc_int8_exe.forward()
+        qoutput, min_range, max_range, shift_data = fc_int8_exe.forward()
 
         if no_bias:
             assert_almost_equal(output.asnumpy(), qoutput.asnumpy())

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -317,7 +317,7 @@ def test_quantized_fc():
             fc_int8_exe.arg_dict[qarg_names[6]][:] = quantized_range
             fc_int8_exe.arg_dict[qarg_names[7]][:] = -quantized_range
             fc_int8_exe.arg_dict[qarg_names[8]][:] = quantized_range
-        qoutput, min_range, max_range, shift_data = fc_int8_exe.forward()
+        qoutput, min_range, max_range = fc_int8_exe.forward()
 
         if no_bias:
             assert_almost_equal(output.asnumpy(), qoutput.asnumpy())


### PR DESCRIPTION
## Description ##
In this PR, it created quantilized fully connected op by using int8 gemm
@pengzhao-intel, @TaoLv , @ciyongch 

## Feature changes ##
### New features ###
- Support quantilized fully connected op by using int8 gemm
- Support int8 bias by using beta offset

### Unit-test changes ###
- Update testcase test_quantized_fc in tests/python/quantization/test_quantization.py
- Check consistency with original mx.sym.FullyConnected implementation.

## Checklist ##
 - [X] Passed code style checking (make lint).
 - [X] All changes have test coverage.
 - [ ] Code is well-documented.
